### PR TITLE
Add static signIn method to hide Navigation.push

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,35 @@ github_signin_aksoyhlc: any
 	///TODO: use response data  
 ```
 
+## Example 2
+```dart  
+	var params = GithubParamsModel(  
+		clientId: 'xxxxxx',  
+		clientSecret: 'yyyyyy',  
+		callbackUrl: 'http://example.com',  
+		scopes: 'read:user,user:email',  
+	);  
+	  
+	GithubSignInResponse result = await GithubSignIn.signIn(context, params: params);
+
+    	if (result.status != ResultStatus.success) {  
+		// handle error
+		print(result.message);
+	} else {
+		///TODO: use result  
+	}  
+```
+
+
 ### Custom AppBar
 ```dart
 	GithubSignIn(
-      params: params,
-      appBar: PreferredSize(
-        child: AppBar(
-          title: Text("Github Sign In"),
-        ),
-        preferredSize: const Size.fromHeight(56),
-      ),
-    )
+		params: params,
+		appBar: PreferredSize(
+			child: AppBar(
+  				title: Text("Github Sign In"),
+			),
+			preferredSize: const Size.fromHeight(56),
+		)
+	)
 ```

--- a/lib/src/login_screen.dart
+++ b/lib/src/login_screen.dart
@@ -20,6 +20,20 @@ class GithubSignIn extends StatefulWidget {
 
   @override
   State<GithubSignIn> createState() => _GithubSignInState();
+
+  // create a static method to hide the navigator.push
+  static Future<GithubSignInResponse> signIn(BuildContext context, {required GithubParamsModel params}) async {
+    dynamic result = await Navigator.push(context,
+        MaterialPageRoute(builder: (context) => GithubSignIn(params: params)));
+    if (result == null) {
+      return GithubSignInResponse(
+        status: ResultStatus.error,
+        message: "User cancelled the sign in or error occurred",
+      );
+    } else {
+      return result as GithubSignInResponse;
+    }
+  }
 }
 
 class _GithubSignInState extends State<GithubSignIn> {


### PR DESCRIPTION
Add a static method `signIn` to the `GithubSignIn` class . The method encapsulates the `Navigator.push` logic and allows for easier usage of the `GithubSignIn` with less boilerplate code.